### PR TITLE
Fix negative progress display bug

### DIFF
--- a/Owner/Views/ProfileTabView.swift
+++ b/Owner/Views/ProfileTabView.swift
@@ -116,7 +116,7 @@ struct ProfileHeaderView: View {
     }
     
     private func calculateProgress() -> Int {
-        let netWorth = gameManager.netWorth()
+        let netWorth = max(gameManager.netWorth(), 1)  // Clamp to minimum of 1, same as calculateLevel()
         let currentLevelThreshold = pow(10.0, Double(calculateLevel() - 1))
         let nextLevelThreshold = pow(10.0, Double(calculateLevel()))
         let progress = (netWorth - currentLevelThreshold) / (nextLevelThreshold - currentLevelThreshold)


### PR DESCRIPTION
The `ProfileHeaderView` displayed negative level progress due to a discrepancy in `netWorth` handling.

*   The `calculateProgress()` function in `Owner/Views/ProfileTabView.swift` was modified.
*   Previously, `calculateProgress()` used the raw `netWorth` value, which could be 0.
*   This contrasted with `calculateLevel()`, which correctly clamped `netWorth` to a minimum of 1.
*   To resolve this, `calculateProgress()` now also clamps `netWorth` to `max(gameManager.netWorth(), 1)`.
*   This change ensures consistency between level and progress calculations.
*   As a result, when `netWorth` is 0, the progress displays 0% instead of a negative value, aligning with the player being at Level 1.